### PR TITLE
Arreglado lo siguiente:

### DIFF
--- a/app/Resources/views/Emails/registration.html.twig
+++ b/app/Resources/views/Emails/registration.html.twig
@@ -1,0 +1,8 @@
+<h3>{{nombre}} {{apellido}}, bienvenido al Sistema de Convenios de Desempeño Directivo</h3>
+<h4>Estableciendo rutas de mejoramiento</h4>
+
+<p>Usted ha sido registrado como usuario, ahora podrá acceder al sistema con los siguientes datos:</p>
+<p>Usuario: <strong>{{user}}</strong></p>
+<p>Contraseña: <strong>{{pass}}</strong></p>
+
+Para ingresar, pinche el siguiente <a href="{{ url('homepage') }}">enlace</a>

--- a/app/Resources/views/admin/compromisosReales/list.html.twig
+++ b/app/Resources/views/admin/compromisosReales/list.html.twig
@@ -1,11 +1,7 @@
 {% extends 'base_list.html.twig' %}
 {% block list_title %}
     Compromisos {% if sostenedor is defined %} del Sostenedor: <span style="color:#5bc0de;">{{sostenedor.nombre~" "~sostenedor.apellido}}</span> {% endif %}
-{% endblock %}
-
-{% block boton_nuevo %}
-    <a href="{{ path('asignar compromiso', {'role': role}) }}"><button class="btn btn-info" type="button" style="margin:15px;"><i class="fa fa-plus"></i> Asignar Compromiso</button></a>
-{% endblock %}    
+{% endblock %}   
 
 {% block list_header %}
     <th>Compromiso</th>

--- a/app/Resources/views/admin/compromisosReales/list_row.html.twig
+++ b/app/Resources/views/admin/compromisosReales/list_row.html.twig
@@ -1,7 +1,7 @@
 <tr class="gradeX">
     <td>{{ compromiso.compromiso.nombre }}</td>
-    <td>{{ compromiso.compromiso.sostenedor.nombre ~" "~ compromiso.compromiso.sostenedor.apellido }}</td>
-    <td>{{ compromiso.director.nombre~" "~compromiso.director.apellido }}</td>
+    <td>{{ compromiso.compromiso.sostenedor.apellido }} {{ compromiso.compromiso.sostenedor.nombre }}</td>
+    <td>{{ compromiso.director.apellido }} {{ compromiso.director.nombre }}</td>
     <td class="center">
         <div class="btn-group">
             <button data-toggle="dropdown" class="btn btn-info dropdown-toggle" type="button">Operaciones <span class="caret"></span></button>

--- a/app/Resources/views/sostenedor/compromisosReales/list_row.html.twig
+++ b/app/Resources/views/sostenedor/compromisosReales/list_row.html.twig
@@ -1,7 +1,7 @@
 <tr class="gradeX">
     <td>{{ compromiso.compromiso.nombre }}</td>
-    <td>{{ compromiso.compromiso.sostenedor.nombre ~" "~ compromiso.compromiso.sostenedor.apellido }}</td>
-    <td>{{ compromiso.director.nombre~" "~compromiso.director.apellido }}</td>
+    <td>{{ compromiso.compromiso.sostenedor.apellido }} {{ compromiso.compromiso.sostenedor.nombre }}</td>
+    <td>{{ compromiso.director.apellido }} {{ compromiso.director.nombre}}</td>
     <td class="center">
         <div class="btn-group">
             <button data-toggle="dropdown" class="btn btn-info dropdown-toggle" type="button">Operaciones <span class="caret"></span></button>

--- a/src/AppBundle/Controller/Administrador/CompromisoRealController.php
+++ b/src/AppBundle/Controller/Administrador/CompromisoRealController.php
@@ -36,7 +36,7 @@ class CompromisoRealController extends Controlador {
      */
     public function verCompromisoAsignadoAction($id, $idSostenedor, Request $request) {
         $sostenedor = $this->_obtenerUser('AppBundle\Entity\Sostenedor', $idSostenedor, 'view');
-        return $this->_verObject($request, $id, 'AppBundle:CompromisoReal', CompromisoRealType::class, 'compromisoReal', array('sostenedor'=>$sostenedor, 'file_path'=>'getWebPath'));
+        return $this->_verObject($request, $id, 'AppBundle:CompromisoReal', CompromisoRealType::class, 'compromisoReal', array('sostenedor'=>$sostenedor, 'ano' => $this->getUser()->getAno(), 'file_path'=>'getWebPath'));
     }
 
 }

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -6,6 +6,11 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+
+
 class DefaultController extends Controller {
 
     /**
@@ -28,7 +33,7 @@ class DefaultController extends Controller {
             }
         }
     }
-
+    
     /**
      * @Route("/register/administrador", name="administrador_registration")
      */

--- a/src/AppBundle/Controller/Director/CompromisoRealController.php
+++ b/src/AppBundle/Controller/Director/CompromisoRealController.php
@@ -30,7 +30,7 @@ class CompromisoRealController extends Controlador {
      */
     public function verCompromisoAsignadoAction($id, $idSostenedor, Request $request) {
         $sostenedor = $this->getUser()->getSostenedor();
-        return $this->_verObject($request, $id, 'AppBundle:CompromisoReal', CompromisoRealType::class, 'compromisoReal', array('sostenedor'=>$sostenedor, 'file_path'=>'getWebPath'));
+        return $this->_verObject($request, $id, 'AppBundle:CompromisoReal', CompromisoRealType::class, 'compromisoReal', array('sostenedor'=>$sostenedor, 'file_path'=>'getWebPath', 'ano'=>$this->getUser()->getAno()));
     }
 
     /**

--- a/src/AppBundle/Controller/Sostenedor/CompromisoRealController.php
+++ b/src/AppBundle/Controller/Sostenedor/CompromisoRealController.php
@@ -28,7 +28,7 @@ class CompromisoRealController extends Controlador {
      */
     public function asignarCompromisoAction(Request $request) {
         $sostenedor = $this->getUser();
-        return $this->_crearObject($request, CompromisoReal::class, CompromisoRealType::class, 'ver compromisos asignados', 'compromisoReal', $this->getUser()->getAno(), array('sostenedor'=>$sostenedor));
+        return $this->_crearObject($request, CompromisoReal::class, CompromisoRealType::class, 'ver compromisos asignados', 'compromisoReal', $this->getUser()->getAno(), array('sostenedor'=>$sostenedor, 'ano'=>$this->getUser()->getAno(), 'read_only_estado_director'=>false));
     }
 
     /**
@@ -36,7 +36,7 @@ class CompromisoRealController extends Controlador {
      */
     public function editarCompromisoAsignadoAction($id, Request $request) {
         $sostenedor = $this->getUser();
-        return $this->_editarObject($request, $id, 'AppBundle:CompromisoReal', CompromisoRealType::class, 'ver compromisos asignados', 'compromisoReal', array('sostenedor'=>$sostenedor, 'file_path'=>'getWebPath'));
+        return $this->_editarObject($request, $id, 'AppBundle:CompromisoReal', CompromisoRealType::class, 'ver compromisos asignados', 'compromisoReal', array('sostenedor'=>$sostenedor, 'file_path'=>'getWebPath', 'ano'=>$this->getUser()->getAno(), 'read_only_estado_director'=>true));
     }
 
     /**
@@ -44,7 +44,7 @@ class CompromisoRealController extends Controlador {
      */
     public function verCompromisoAsignadoAction($id, Request $request) {
         $sostenedor = $this->getUser();
-        return $this->_verObject($request, $id, 'AppBundle:CompromisoReal', CompromisoRealType::class, 'compromisoReal', array('sostenedor'=>$sostenedor, 'file_path'=>'getWebPath'));
+        return $this->_verObject($request, $id, 'AppBundle:CompromisoReal', CompromisoRealType::class, 'compromisoReal', array('sostenedor'=>$sostenedor, 'file_path'=>'getWebPath', 'ano'=>$this->getUser()->getAno()));
     }
     
     /**

--- a/src/AppBundle/Controller/Utils/DBUsersUtilsTrait.php
+++ b/src/AppBundle/Controller/Utils/DBUsersUtilsTrait.php
@@ -62,6 +62,7 @@ trait DBUsersUtilsTrait {
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
             $userManager = $this->_obtenerUserManager($class);
+            $this->_enviarEmailRegistro($user);
             $userManager->updateUser($user, true);
             $this->addFlash('success', 'flash.success.cambio');
             return $this->redirectToRoute($redirect, $redirect_params);
@@ -95,4 +96,19 @@ trait DBUsersUtilsTrait {
         return $this->container->get('my_pugx_user_manager');
     }
 
+    private function _enviarEmailRegistro($user){
+        $message = \Swift_Message::newInstance()
+            ->setSubject('Nuevo usuario registrado')
+            ->setFrom('mensajes@softwaretrident.com')
+            ->setTo($user->getEmail())
+            ->setBody(
+                $this->renderView(
+                    'Emails/registration.html.twig',
+                    array('nombre' => $user->getNombre(), 'apellido' => $user->getApellido(), 'user' => $user->getUsername(), 'pass' => $user->getPlainPassword())
+                ),
+                'text/html'
+            )
+        ;
+        $this->get('mailer')->send($message);
+    }
 }

--- a/src/AppBundle/Entity/Sostenedor.php
+++ b/src/AppBundle/Entity/Sostenedor.php
@@ -290,6 +290,22 @@ class Sostenedor extends User {
     public function getCompromisos() {
         return $this->compromisos;
     }
+    
+    /**
+     * Get compromisos año
+     *
+     * @return \Doctrine\Common\Collections\Collection 
+     */
+    public function getCompromisosAno($ano) {
+        $comps = $this->compromisos;
+        $retcomps = array();
+        foreach($comps as $c){
+            if($c->getAno() === $ano){
+                array_push($retcomps, $c);
+            }
+        }
+        return $retcomps;
+    }
 
     /**
      * Set ciudad

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -122,5 +122,14 @@ abstract class User extends BaseUser {
     public function getAno() {
         return $this->ano;
     }
+    
+    /**
+     * Get nombre entero
+     *
+     * @return string 
+     */
+    public function getNombreEntero(){
+        return $this->apellido . " " . $this->nombre;
+    }
 
 }

--- a/src/AppBundle/Form/Type/CompromisoRealDirectorType.php
+++ b/src/AppBundle/Form/Type/CompromisoRealDirectorType.php
@@ -13,19 +13,19 @@ class CompromisoRealDirectorType extends AbstractType {
     public function buildForm(FormBuilderInterface $builder, array $options) {
         $builder->add('verificado', CheckboxType::class, array(
             'required' => false,
-            'disabled' => true
+            'read_only' => true
         ));
         $builder->add('compromiso', EntityType::class, array(
             'class' => 'AppBundle:Compromiso',
             'choice_label' => 'nombre',
-            'choices' => $options['sostenedor']->getCompromisos(),
-            'disabled' => true
+            'choices' => $options['sostenedor']->getCompromisosAno($options['ano']),
+            'read_only' => true
         ));
         
         $builder->add('estadoSostenedor', EntityType::class, array(
             'class' => 'AppBundle:Estado',
             'choice_label' => 'nombre',
-            'disabled' => true
+            'read_only' => true
         ));
         $builder->add('estadoDirector', EntityType::class, array(
             'class' => 'AppBundle:Estado',
@@ -33,20 +33,21 @@ class CompromisoRealDirectorType extends AbstractType {
         ));
         $builder->add('director', EntityType::class, array(
             'class' => 'AppBundle:Director',
-            'choice_label' => 'nombre',
+            'choice_label' => 'getNombreEntero',
             'choices' => $options['sostenedor']->getDirectores(),
-            'disabled' => true
+            'read_only' => true
         ));
         $builder->add('medioVerificacion', ArchivoType::class, array(
             'file_path' => $options['file_path'],
-            'disabled' => true
+            'read_only' => true
         ));
     }
     
     public function setDefaultOptions(OptionsResolverInterface $resolver) {
         $resolver->setDefaults(array(
             'sostenedor' => null,
-            'file_path' => null
+            'file_path' => null,
+            'ano' => null,
         ));
     }
 

--- a/src/AppBundle/Form/Type/CompromisoRealType.php
+++ b/src/AppBundle/Form/Type/CompromisoRealType.php
@@ -17,7 +17,7 @@ class CompromisoRealType extends AbstractType {
         $builder->add('compromiso', EntityType::class, array(
             'class' => 'AppBundle:Compromiso',
             'choice_label' => 'nombre',
-            'choices' => $options['sostenedor']->getCompromisos()
+            'choices' => $options['sostenedor']->getCompromisosAno($options['ano']),
         ));
         
         $builder->add('estadoSostenedor', EntityType::class, array(
@@ -27,11 +27,11 @@ class CompromisoRealType extends AbstractType {
         $builder->add('estadoDirector', EntityType::class, array(
             'class' => 'AppBundle:Estado',
             'choice_label' => 'nombre',
-            'read_only' => true
+            'read_only' => $options['read_only_estado_director']
         ));
         $builder->add('director', EntityType::class, array(
             'class' => 'AppBundle:Director',
-            'choice_label' => 'nombre',
+            'choice_label' => 'getNombreEntero',
             'choices' => $options['sostenedor']->getDirectores()
         ));
         $builder->add('medioVerificacion', ArchivoType::class, array(
@@ -42,7 +42,9 @@ class CompromisoRealType extends AbstractType {
     public function setDefaultOptions(OptionsResolverInterface $resolver) {
         $resolver->setDefaults(array(
             'sostenedor' => null,
-            'file_path' => null
+            'file_path' => null,
+            'ano' => null,
+            'read_only_estado_director' => false
         ));
     }
 

--- a/src/AppBundle/Form/Type/HitoType.php
+++ b/src/AppBundle/Form/Type/HitoType.php
@@ -41,7 +41,7 @@ class HitoType extends AbstractType {
         ));
         $builder->add('miembros', EntityType::class, array(
             'class' => 'AppBundle:Miembro',
-            'choice_label' => 'username',
+            'choice_label' => 'getNombreCompleto',
             'choices' => $options['director']->getMiembros(),
             'multiple' => true
         ));


### PR DESCRIPTION
-Mostrar bien los nombre de los directores en el form de crear colegio (y verificar todos los forms por las dudas) /form de asignar compromiso
-Que el sostenedor al asignar un compromiso pueda asignar un estado de director (pero que no pueda editarlo)
-Enviar un email cada vez que se crea un usuario
-ARREGLAR todos los listados de compromisos para que solo muestre los de ESE año.